### PR TITLE
bail out on any websocket read error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -146,11 +146,9 @@ func (conn *Conn) run(ctx context.Context) {
 			}
 			_, r, err := conn.conn.Reader(ctx)
 			switch {
-			case err != nil && (errors.Is(err, context.Canceled) || errors.As(err, &websocket.CloseError{})):
-				return
 			case err != nil:
 				conn.h.Errf("reader error: %v", err)
-				continue
+				return
 			}
 			buf, err := io.ReadAll(r)
 			if err != nil {


### PR DESCRIPTION
At the moment, the errors.As and errors.Is are unable to correctly detect websocket.CloseError due to further wrapping happening on the error. In the case that an error is returned, the client enters as busy loop.